### PR TITLE
Build docker image with Nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -54,10 +54,33 @@
           # rank() integration tests download the embedding model (network).
           doCheck = false;
         };
+
+        dockerImage = pkgs.dockerTools.buildImage {
+          name = patent.pname;
+          tag = patent.version;
+
+          copyToRoot = pkgs.buildEnv {
+            name = "image-root";
+            paths = [
+              patent
+              pkgs.cacert
+            ];
+            pathsToLink = [
+              "/bin"
+              "/etc"
+            ];
+          };
+
+          config = {
+            Entrypoint = [ "/bin/patent" ];
+            Env = [ "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt" ];
+          };
+        };
       in
       {
         packages.default = patent;
         packages.patent = patent;
+        packages.dockerImage = dockerImage;
 
         apps.default = flake-utils.lib.mkApp { drv = patent; };
 


### PR DESCRIPTION
Hey,

I wanted to add this too but you merged the PR before I had the chance to do it ^^

This PR will add a docker image builder using the Nix flake.

You can build the image with:
- Create the docker tarball: `nix build .#dockerImage`
- Load it into docker: `docker load < result`
- Run with `docker run patent:0.3.0 "CLI tool to share terminal session"`

The built docker layer is not based on any distribution and should contain the necessary libraries and only the `patent` program to run