### PR TITLE
Fix: #26 Add Config file + environment variable overrides.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ path = "src/bin/patent/main.rs"
 
 [dependencies]
 # CLI / runtime
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 clap_complete = "4"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 futures = "0.3"
@@ -57,8 +57,11 @@ scraper = "0.27"
 anyhow = "1"
 thiserror = "2"
 
-# Stable per-user cache dir for the embedding model
+# Stable per-user cache dir for the embedding model and config file
 dirs = "6"
+
+# Config file
+toml = "0.8"
 
 # Ranking (M3) — semantic embeddings, model downloads on first run
 fastembed = "5"

--- a/src/bin/patent/cli.rs
+++ b/src/bin/patent/cli.rs
@@ -16,16 +16,19 @@ pub struct Cli {
     pub limit: u32,
 
     /// LLM model for the verdict. Defaults to qwen2.5 for Ollama; required with --api-base.
-    #[arg(long)]
+    /// Can also be set via PATENT_MODEL or config file.
+    #[arg(long, env = "PATENT_MODEL")]
     pub model: Option<String>,
 
     /// Use an OpenAI-compatible API instead of local Ollama. Base URL ending in
     /// /v1, e.g. https://api.openai.com/v1 or http://localhost:1234/v1.
-    #[arg(long, value_name = "URL")]
+    /// Can also be set via PATENT_API_BASE or config file.
+    #[arg(long, value_name = "URL", env = "PATENT_API_BASE")]
     pub api_base: Option<String>,
 
-    /// API key for --api-base (or set OPENAI_API_KEY). Omit for servers without auth.
-    #[arg(long, value_name = "KEY")]
+    /// API key for --api-base. Falls back to PATENT_API_KEY, config file, then
+    /// OPENAI_API_KEY. Omit for servers without auth.
+    #[arg(long, value_name = "KEY", env = "PATENT_API_KEY")]
     pub api_key: Option<String>,
 
     /// Skip the LLM verdict for an instant, search-only result.

--- a/src/bin/patent/config.rs
+++ b/src/bin/patent/config.rs
@@ -1,0 +1,67 @@
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Config {
+    pub model: Option<String>,
+    pub api_base: Option<String>,
+    pub api_key: Option<String>,
+}
+
+fn config_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|d| d.join("patent").join("config.toml"))
+}
+
+pub fn load() -> anyhow::Result<Config> {
+    let path = match config_path() {
+        Some(p) => p,
+        None => return Ok(Config::default()),
+    };
+    match std::fs::read_to_string(&path) {
+        Ok(text) => toml::from_str(&text).map_err(|e| anyhow::anyhow!("{}: {e}", path.display())),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Config::default()),
+        Err(e) => Err(anyhow::anyhow!("{}: {e}", path.display())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_all_fields() {
+        let cfg: Config = toml::from_str(
+            r#"
+            model    = "gpt-4o-mini"
+            api_base = "https://api.openai.com/v1"
+            api_key  = "sk-test"
+            "#,
+        )
+        .unwrap();
+        assert_eq!(cfg.model.as_deref(), Some("gpt-4o-mini"));
+        assert_eq!(cfg.api_base.as_deref(), Some("https://api.openai.com/v1"));
+        assert_eq!(cfg.api_key.as_deref(), Some("sk-test"));
+    }
+
+    #[test]
+    fn empty_file_is_ok() {
+        let cfg: Config = toml::from_str("").unwrap();
+        assert!(cfg.model.is_none());
+        assert!(cfg.api_base.is_none());
+        assert!(cfg.api_key.is_none());
+    }
+
+    #[test]
+    fn partial_fields_ok() {
+        let cfg: Config = toml::from_str(r#"model = "qwen2.5:3b""#).unwrap();
+        assert_eq!(cfg.model.as_deref(), Some("qwen2.5:3b"));
+        assert!(cfg.api_base.is_none());
+    }
+
+    #[test]
+    fn unknown_field_is_error() {
+        assert!(toml::from_str::<Config>(r#"typo_key = "oops""#).is_err());
+    }
+}

--- a/src/bin/patent/main.rs
+++ b/src/bin/patent/main.rs
@@ -1,6 +1,7 @@
 //! `patent` binary — thin CLI/TUI shell over the `patent` library.
 
 mod cli;
+mod config;
 mod tui;
 
 use clap::{CommandFactory, Parser};
@@ -110,19 +111,35 @@ async fn main() -> anyhow::Result<()> {
         .expect("idea is required when not using --completions");
     validate_idea(&idea)?;
 
-    // Validate backend flags up front so the contract doesn't depend on the
-    // query's similarity score (the verdict step is skipped on --fast and on
-    // low-relevance results).
-    if !args.fast && args.api_base.is_some() && args.model.is_none() {
+    // Load config file; missing file is fine, malformed file is a hard error.
+    let cfg = config::load()?;
+
+    // Resolve each setting: CLI flag / env var (via clap) > config file > built-in default.
+    // OPENAI_API_KEY is a well-known fallback for api_key only (checked last).
+    let api_base = args.api_base.or(cfg.api_base);
+    // Track whether the key came from an explicit source (not the global OPENAI_API_KEY
+    // fallback) so we can warn accurately when api_base is absent.
+    let api_key_explicit = args.api_key.is_some() || cfg.api_key.is_some();
+    let api_key = args
+        .api_key
+        .or(cfg.api_key)
+        .or_else(|| std::env::var("OPENAI_API_KEY").ok());
+    let model = args.model.or(cfg.model);
+
+    // Validate resolved backend settings up front so the contract doesn't
+    // depend on the query's similarity score.
+    if !args.fast && api_base.is_some() && model.is_none() {
         anyhow::bail!(
-            "--api-base requires a model; pass --model <NAME> (e.g. --model gpt-4o-mini)."
+            "api_base is set but no model was specified. \
+             Pass --model <NAME>, set PATENT_MODEL, or add `model = \"...\"` to \
+             ~/.config/patent/config.toml."
         );
     }
-    if args.api_key.is_some() && args.api_base.is_none() {
-        eprintln!("warning: --api-key has no effect without --api-base; using local Ollama.");
+    if api_key_explicit && api_base.is_none() {
+        eprintln!("warning: api_key has no effect without api_base; using local Ollama.");
     }
-    if args.fast && args.api_base.is_some() {
-        eprintln!("warning: --fast skips the LLM, so --api-base has no effect.");
+    if args.fast && api_base.is_some() {
+        eprintln!("warning: --fast skips the LLM, so api_base has no effect.");
     }
 
     let query = build_query(&idea);
@@ -211,25 +228,18 @@ async fn main() -> anyhow::Result<()> {
              try rephrasing with specific technical terms.",
         )
     } else {
-        // --api-base without --model already errored up front, so None here means
+        // api_base without model already errored up front, so None here means
         // the local Ollama default.
-        let model = args
-            .model
+        let model = model
             .clone()
             .unwrap_or_else(|| patent::ollama::DEFAULT_MODEL.to_string());
 
-        let llm: Box<dyn patent::Llm> = match &args.api_base {
-            Some(base) => {
-                let key = args
-                    .api_key
-                    .clone()
-                    .or_else(|| std::env::var("OPENAI_API_KEY").ok());
-                Box::new(patent::openai::OpenAi::new(
-                    base.clone(),
-                    model.clone(),
-                    key,
-                ))
-            }
+        let llm: Box<dyn patent::Llm> = match &api_base {
+            Some(base) => Box::new(patent::openai::OpenAi::new(
+                base.clone(),
+                model.clone(),
+                api_key.clone(),
+            )),
             None => Box::new(patent::ollama::Ollama::new(
                 patent::ollama::DEFAULT_ENDPOINT,
                 model.clone(),


### PR DESCRIPTION
Config file support (~/.config/patent/config.toml)

  Users no longer need to pass --api-base, --api-key, and --model on every run. A TOML config file is loaded at startup
  with full precedence: CLI flag > env var > config file > built-in default.

  - New src/bin/patent/config.rs — Config struct with #[serde(deny_unknown_fields)] (typos are caught, not silently
  ignored), load() handles missing file silently and returns a hard error with file path for malformed files
  - Added PATENT_MODEL, PATENT_API_BASE, PATENT_API_KEY env vars via clap's env feature
  - OPENAI_API_KEY remains a final fallback for api_key
  - Validation errors now hint the config file as a fix location