### PR TITLE
fix: replace block_on with async/await to prevent runtime panic

### DIFF
--- a/src/bin/patent/main.rs
+++ b/src/bin/patent/main.rs
@@ -115,7 +115,7 @@ async fn main() -> anyhow::Result<()> {
             if !std::io::stdout().is_terminal() {
                 anyhow::bail!("No idea provided. Usage: patent \"your dev-tool idea here\"");
             }
-            return tui::run_interactive();
+            return tui::run_interactive().await;
         }
     };
     validate_idea(&idea)?;
@@ -296,7 +296,7 @@ async fn main() -> anyhow::Result<()> {
         });
         println!("{}", serde_json::to_string_pretty(&output)?);
     } else {
-        tui::run_with_results(&idea, verdict, ranked)?;
+        tui::run_with_results(&idea, verdict, ranked).await?;
     }
 
     std::process::exit(exit_code)

--- a/src/bin/patent/tui.rs
+++ b/src/bin/patent/tui.rs
@@ -910,13 +910,13 @@ fn open_selected(app: &App) {
 }
 
 /// Launch the TUI with pre-computed results (CLI provided an idea).
-pub fn run_with_results(idea: &str, verdict: Verdict, matches: Vec<Match>) -> anyhow::Result<()> {
+pub async fn run_with_results(idea: &str, verdict: Verdict, matches: Vec<Match>) -> anyhow::Result<()> {
     let app = App::new(idea, verdict, matches);
-    run_tui(app, Phase::Results)
+    run_tui(app, Phase::Results).await
 }
 
 /// Launch the TUI in interactive search mode (no idea on CLI).
-pub fn run_interactive() -> anyhow::Result<()> {
+pub async fn run_interactive() -> anyhow::Result<()> {
     let app = App::new(
         "",
         Verdict {
@@ -936,9 +936,10 @@ pub fn run_interactive() -> anyhow::Result<()> {
             cursor: 0,
         },
     )
+    .await
 }
 
-fn run_tui(app: App, initial_phase: Phase) -> anyhow::Result<()> {
+async fn run_tui(app: App, initial_phase: Phase) -> anyhow::Result<()> {
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
         let _ = execute!(std::io::stdout(), DisableMouseCapture);
@@ -949,8 +950,14 @@ fn run_tui(app: App, initial_phase: Phase) -> anyhow::Result<()> {
     let mut terminal = ratatui::init();
     let _ = execute!(std::io::stdout(), EnableMouseCapture);
 
-    let rt = tokio::runtime::Handle::current();
-    let result = rt.block_on(run_loop(&mut terminal, app, initial_phase));
+    // let rt = tokio::runtime::Handle::current();
+    // let result = rt.block_on(run_loop(&mut terminal, app, initial_phase));
+    let result = run_loop(
+    &mut terminal,
+    app,
+    initial_phase,
+    )
+    .await;
 
     let _ = execute!(std::io::stdout(), DisableMouseCapture);
     ratatui::restore();


### PR DESCRIPTION
## Problem

Running the project panics immediately with:

  Cannot start a runtime from within a runtime.

This happens because `run_tui`, `run_with_results`, and `run_interactive`
were synchronous functions that called `tokio::runtime::Handle::current().block_on(...)`
to drive the async `run_loop`. Since `main` is already an async tokio runtime
(`#[tokio::main]`), calling `block_on` from inside it is not allowed and panics.

## Fix

Converted `run_tui`, `run_with_results`, and `run_interactive` to `async fn`
and replaced the `block_on` call with a direct `.await`. Updated the call
sites in `main.rs` accordingly.

## How to reproduce (before fix)

cargo run -- "some idea"
# or just: cargo run

→ thread 'main' panicked at 'Cannot start a runtime from within a runtime.'

## Changes

- `tui.rs`: made `run_tui`, `run_with_results`, and `run_interactive` async
- `main.rs`: added `.await` at both call sites