### PR TITLE
Bump minimum debian req for glibc2.38

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Pre-built binaries are on the [releases page](https://github.com/r14dd/patent/re
 - Fedora / RHEL: `sudo dnf install openssl-devel gcc-c++`
 - Ubuntu / Debian: `sudo apt install libssl-dev g++`
 
-**glibc 2.38+** — both the prebuilt binaries and a from-source `cargo install` require glibc 2.38 or newer (Ubuntu 22.10+, Debian 12+, Fedora 38+). The bundled ONNX Runtime that powers local semantic search depends on it. On older distributions such as Ubuntu 22.04 (glibc 2.35), build inside a newer toolchain — e.g. a `debian:12` / `ubuntu:24.04` container — rather than on the host ([#37](https://github.com/r14dd/patent/issues/37)).
+**glibc 2.38+** — both the prebuilt binaries and a from-source `cargo install` require glibc 2.38 or newer (Ubuntu 22.10+, Debian 13+, Fedora 38+). The bundled ONNX Runtime that powers local semantic search depends on it. On older distributions such as Ubuntu 22.04 (glibc 2.35), build inside a newer toolchain — e.g. a `debian:13` / `ubuntu:24.04` container — rather than on the host ([#37](https://github.com/r14dd/patent/issues/37)).
 
 ## Usage
 


### PR DESCRIPTION
<!-- Thanks for contributing to patent! Please fill in the checklist below. -->

## What this changes

Addition to #37 - The readme currently states that at minimum debian 12 (bookwork) is required, but that ships with glibc2.36 (not 2.38), so the minimum supported debian version is 13 (trixie) which ships with 2.41.

## Checklist

- [ ] `cargo fmt --all --check` passes
- [ ] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test` passes
- [x] Docs / README / CHANGELOG updated if behavior or flags changed

## If this adds a new source adapter

- [ ] Added the `Source` variant in `src/model.rs`
- [ ] Implemented `SourceAdapter` (with a `with_base_url` test constructor)
- [ ] Registered in `build_source()` **and** `detect_sources()` in `src/sources/mod.rs`
- [ ] Added a `wiremock` integration test in `tests/sources.rs` (happy path, empty results, server error)
- [ ] `every_built_source_is_reachable_from_some_idea` still passes

## If this touches the verdict / prompt / LLM backends

- [ ] Preserves the verdict-integrity rules — no copy that asserts something *doesn't* exist; output stays scoped to "found in the sources checked"
- [ ] The `guard_headline` / `floor_level` guards in `verdict.rs` are intact
