### PR TITLE
Add the x86_64 Windows release target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,10 +127,6 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
-      - uses: swatinem/rust-cache@v2
-        with:
-          key: ${{ join(matrix.targets, '-') }}
-          cache-provider: ${{ matrix.cache_provider }}
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,10 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
+      - uses: swatinem/rust-cache@v2
+        with:
+          key: ${{ join(matrix.targets, '-') }}
+          cache-provider: ${{ matrix.cache_provider }}
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -18,9 +18,6 @@ publish-jobs = ["homebrew"]
 # Intel macOS is omitted: ort-sys ships no Intel-macOS prebuilt. It installs
 # via `cargo install patent` with a local onnxruntime.
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
-# Temporary: build every target on PRs so the Windows build is verified
-# before it is tagged. Flip back to "plan" once it has passed.
-pr-run-mode = "upload"
 # The onnxruntime prebuilt is built against the dynamic CRT (/MD); dist's
 # default +crt-static links libucrt and leaves its __imp_* CRT imports
 # unresolved (LNK2019). Users need the VC++ Redistributable, which every

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -15,10 +15,12 @@ installers = ["shell", "homebrew"]
 tap = "r14dd/homebrew-patent"
 publish-jobs = ["homebrew"]
 # Target platforms to build apps for (Rust target-triple syntax).
-# Intel macOS and Windows are omitted: ort-sys static linking has unresolved
-# MSVC externals and no Intel-macOS prebuilt. Those platforms install via
-# `cargo install patent` with a local onnxruntime.
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu"]
+# Intel macOS is omitted: ort-sys ships no Intel-macOS prebuilt. It installs
+# via `cargo install patent` with a local onnxruntime.
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+# Temporary: build every target on PRs so the Windows build is verified
+# before it is tagged. Flip back to "plan" once it has passed.
+pr-run-mode = "upload"
 
 # Build the Linux targets on a newer image: the onnxruntime prebuilt needs
 # glibc >= 2.38, which the default image is too old for.

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -21,6 +21,11 @@ targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-unknown-
 # Temporary: build every target on PRs so the Windows build is verified
 # before it is tagged. Flip back to "plan" once it has passed.
 pr-run-mode = "upload"
+# The onnxruntime prebuilt is built against the dynamic CRT (/MD); dist's
+# default +crt-static links libucrt and leaves its __imp_* CRT imports
+# unresolved (LNK2019). Users need the VC++ Redistributable, which every
+# maintained Windows install already has.
+msvc-crt-static = false
 
 # Build the Linux targets on a newer image: the onnxruntime prebuilt needs
 # glibc >= 2.38, which the default image is too old for.


### PR DESCRIPTION
Adds `x86_64-pc-windows-msvc` to the cargo-dist targets (#36). `pr-run-mode` is temporarily `upload` so this PR builds every target and the Windows link is verified before a tag; it flips back to `plan` before merge.